### PR TITLE
Remove the mutable rule limit (rule -104)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,6 @@ Each player always has exactly one vote.
 
 The winner is the first player to achieve 200 (positive) points.
 
-### Rule -104.
-
-At no time may there be more than 25 mutable rules.
-
 ### Rule -103.
 
 If two or more mutable rules conflict with one another, or if two or more immutable rules conflict with one another, then the rule with the lowest ordinal number takes precedence.


### PR DESCRIPTION
I don't see how the mutable rule limit serves any purpose. Having a limit of 25 mutable rules is just a barrier we're going to run into, so it makes sense to get rid of it.